### PR TITLE
scenarios

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import Login from './pages/Login/Login.jsx'
 import Scenario from './pages/Scenarios/Scenario.jsx'
 import Editor from './pages/Editor/Editor.jsx'
 import Results from './pages/Results/Results.jsx'
+import ScenarioDetailPage from './pages/Scenarios/ScenarioDetailPage'
 import axios from 'axios'
 import './App.css'
 import UserProfile from '/src/components/UserProfile'
@@ -47,6 +48,10 @@ function App() {
 
         <Route path="/scenario" element={<Layout page="Scenario" user={user}/>}>
           <Route path="/scenario" element={<Scenario user={user}/>}/>
+        </Route>
+
+        <Route path="/scenario/detail" element={<Layout page="Scenario Detail" user={user}/>}>
+          <Route index element={<ScenarioDetailPage />} />
         </Route>
 
         <Route path="/scenario/edit" element={<Editor user={user}/>}/>

--- a/client/src/pages/Scenarios/InvestmentWizard.jsx
+++ b/client/src/pages/Scenarios/InvestmentWizard.jsx
@@ -1,0 +1,260 @@
+import React, { useState } from 'react';
+
+const VALID_TAX = ['non-retirement', 'pre-tax', 'after-tax'];
+
+const InvestmentWizard = ({ onSubmit, onClose }) => {
+  const [step, setStep] = useState(1);
+  const totalSteps = 4;
+
+  // Step 1
+  const [investmentName, setInvestmentName] = useState('');
+  const [description, setDescription] = useState('');
+  const [taxStatus, setTaxStatus] = useState('');
+  const [value, setValue] = useState('');
+  const [expenseRatio, setExpenseRatio] = useState('');
+
+  // Step 2
+  const [returnDistType, setReturnDistType] = useState('fixed');
+  const [returnValue, setReturnValue] = useState('');
+  const [returnMean, setReturnMean] = useState('');
+  const [returnSigma, setReturnSigma] = useState('');
+  const [returnLower, setReturnLower] = useState('');
+  const [returnUpper, setReturnUpper] = useState('');
+
+  // Step 3
+  const [incomeDistType, setIncomeDistType] = useState('fixed');
+  const [incomeValue, setIncomeValue] = useState('');
+  const [incomeMean, setIncomeMean] = useState('');
+  const [incomeSigma, setIncomeSigma] = useState('');
+  const [incomeLower, setIncomeLower] = useState('');
+  const [incomeUpper, setIncomeUpper] = useState('');
+
+  // Error state
+  const [error, setError] = useState('');
+
+  // Helpers
+  const toNumber = (str) => {
+    const n = Number(str);
+    return isNaN(n) ? null : n;
+  };
+
+  const buildDistribution = (distType, value, mean, sigma, lower, upper) => {
+    if (distType === 'fixed') {
+      return { distType, value: toNumber(value) };
+    }
+    if (distType === 'normal' || distType === 'GBM') {
+      return { distType, mean: toNumber(mean), sigma: toNumber(sigma) };
+    }
+    // uniform
+    return { distType, lower: toNumber(lower), upper: toNumber(upper) };
+  };
+
+  const validateStep = () => {
+    setError('');
+    if (step === 1) {
+      if (!investmentName.trim()) return 'Name is required';
+      if (!VALID_TAX.includes(taxStatus)) return 'Please select a valid tax status';
+      if (toNumber(value) === null) return 'Value must be a number';
+      if (toNumber(expenseRatio) === null) return 'Expense ratio must be a number';
+    }
+    if (step === 2) {
+      if (returnDistType === 'fixed' && toNumber(returnValue) === null) return 'Return value is required';
+      if ((returnDistType === 'normal' || returnDistType === 'GBM') && (toNumber(returnMean) === null || toNumber(returnSigma) === null)) {
+        return 'Return mean & sigma are required';
+      }
+      if (returnDistType === 'uniform' && (toNumber(returnLower) === null || toNumber(returnUpper) === null)) {
+        return 'Return lower & upper are required';
+      }
+    }
+    if (step === 3) {
+      if (incomeDistType === 'fixed' && toNumber(incomeValue) === null) return 'Income value is required';
+      if ((incomeDistType === 'normal' || incomeDistType === 'GBM') && (toNumber(incomeMean) === null || toNumber(incomeSigma) === null)) {
+        return 'Income mean & sigma are required';
+      }
+      if (incomeDistType === 'uniform' && (toNumber(incomeLower) === null || toNumber(incomeUpper) === null)) {
+        return 'Income lower & upper are required';
+      }
+    }
+    return '';
+  };
+
+  const handleNext = () => {
+    const msg = validateStep();
+    if (msg) return setError(msg);
+    setError('');
+    setStep((s) => Math.min(s + 1, totalSteps));
+  };
+
+  const handlePrev = () => {
+    setError('');
+    setStep((s) => Math.max(s - 1, 1));
+  };
+
+  const handleSubmit = () => {
+    const msg = validateStep();
+    if (msg) return setError(msg);
+
+    const newInvestment = {
+      name: investmentName.trim(),
+      investmentType: {
+        name: investmentName.trim(),
+        description: description.trim(),
+        expenseRatio: toNumber(expenseRatio),
+        returnDistribution: buildDistribution(
+          returnDistType,
+          returnValue,
+          returnMean,
+          returnSigma,
+          returnLower,
+          returnUpper
+        ),
+        incomeDistribution: buildDistribution(
+          incomeDistType,
+          incomeValue,
+          incomeMean,
+          incomeSigma,
+          incomeLower,
+          incomeUpper
+        ),
+      },
+      taxStatus,
+      value: toNumber(value),
+    };
+
+    onSubmit(newInvestment);
+  };
+
+  return (
+    <div style={modalStyle}>
+      <div style={modalContentStyle}>
+        <h2>Add Investment (Step {step}/{totalSteps})</h2>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+
+        {step === 1 && (
+          <>
+            <label>Name</label>
+            <input value={investmentName} onChange={e => setInvestmentName(e.target.value)} />
+            <label>Description</label>
+            <input value={description} onChange={e => setDescription(e.target.value)} />
+            <label>Tax Status</label>
+            <select value={taxStatus} onChange={e => setTaxStatus(e.target.value)}>
+              <option value="">— select —</option>
+              <option value="non-retirement">Non‑Retirement</option>
+              <option value="pre-tax">Pre‑Tax</option>
+              <option value="after-tax">After‑Tax</option>
+            </select>
+            <label>Value</label>
+            <input type="number" value={value} onChange={e => setValue(e.target.value)} />
+            <label>Expense Ratio</label>
+            <input type="number" value={expenseRatio} onChange={e => setExpenseRatio(e.target.value)} />
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <label>Return Dist Type</label>
+            <select value={returnDistType} onChange={e => setReturnDistType(e.target.value)}>
+              <option value="fixed">Fixed</option>
+              <option value="normal">Normal</option>
+              <option value="GBM">GBM</option>
+              <option value="uniform">Uniform</option>
+            </select>
+            {returnDistType === 'fixed' && (
+              <>
+                <label>Return Value</label>
+                <input type="number" value={returnValue} onChange={e => setReturnValue(e.target.value)} />
+              </>
+            )}
+            {(returnDistType === 'normal' || returnDistType === 'GBM') && (
+              <>
+                <label>Mean</label>
+                <input type="number" value={returnMean} onChange={e => setReturnMean(e.target.value)} />
+                <label>Sigma</label>
+                <input type="number" value={returnSigma} onChange={e => setReturnSigma(e.target.value)} />
+              </>
+            )}
+            {returnDistType === 'uniform' && (
+              <>
+                <label>Lower</label>
+                <input type="number" value={returnLower} onChange={e => setReturnLower(e.target.value)} />
+                <label>Upper</label>
+                <input type="number" value={returnUpper} onChange={e => setReturnUpper(e.target.value)} />
+              </>
+            )}
+          </>
+        )}
+
+        {step === 3 && (
+          <>
+            <label>Income Dist Type</label>
+            <select value={incomeDistType} onChange={e => setIncomeDistType(e.target.value)}>
+              <option value="fixed">Fixed</option>
+              <option value="normal">Normal</option>
+              <option value="GBM">GBM</option>
+              <option value="uniform">Uniform</option>
+            </select>
+            {incomeDistType === 'fixed' && (
+              <>
+                <label>Income Value</label>
+                <input type="number" value={incomeValue} onChange={e => setIncomeValue(e.target.value)} />
+              </>
+            )}
+            {(incomeDistType === 'normal' || incomeDistType === 'GBM') && (
+              <>
+                <label>Mean</label>
+                <input type="number" value={incomeMean} onChange={e => setIncomeMean(e.target.value)} />
+                <label>Sigma</label>
+                <input type="number" value={incomeSigma} onChange={e => setIncomeSigma(e.target.value)} />
+              </>
+            )}
+            {incomeDistType === 'uniform' && (
+              <>
+                <label>Lower</label>
+                <input type="number" value={incomeLower} onChange={e => setIncomeLower(e.target.value)} />
+                <label>Upper</label>
+                <input type="number" value={incomeUpper} onChange={e => setIncomeUpper(e.target.value)} />
+              </>
+            )}
+          </>
+        )}
+
+        {step === 4 && (
+          <div>
+            <h3>Review</h3>
+            <p><strong>Name:</strong> {investmentName}</p>
+            <p><strong>Tax Status:</strong> {taxStatus}</p>
+            <p><strong>Value:</strong> {value}</p>
+            <p><strong>Expense Ratio:</strong> {expenseRatio}</p>
+            <p><strong>Return:</strong> {returnDistType}</p>
+            <p><strong>Income:</strong> {incomeDistType}</p>
+          </div>
+        )}
+
+        <div style={{ marginTop: 20 }}>
+          {step > 1 && <button onClick={handlePrev}>Back</button>}
+          {step < totalSteps && <button onClick={handleNext}>Next</button>}
+          {step === totalSteps && <button onClick={handleSubmit}>Submit Investment</button>}
+          <button onClick={onClose} style={{ marginLeft: 10 }}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const modalStyle = {
+  position: 'fixed',
+  top: 0, left: 0, width: '100%', height: '100%',
+  backgroundColor: 'rgba(0,0,0,0.5)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  zIndex: 1000
+};
+
+const modalContentStyle = {
+  backgroundColor: '#fff',
+  padding: 20,
+  borderRadius: 4,
+  width: '90%',
+  maxWidth: 500
+};
+
+export default InvestmentWizard;

--- a/client/src/pages/Scenarios/ScenarioDetailPage.jsx
+++ b/client/src/pages/Scenarios/ScenarioDetailPage.jsx
@@ -1,0 +1,423 @@
+// scenarioDetailPage.jsx
+import { useState, useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import ScenarioEditModal from './ScenarioEditModal';
+import InvestmentWizard from './InvestmentWizard';
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+
+// Helper function to render a valueDistribution object.
+const renderValueDistribution = (dist) => {
+  if (!dist) return 'N/A';
+  return (
+    <div style={{ marginLeft: '1rem' }}>
+      <div><strong>Distribution Type:</strong> {dist.distType}</div>
+      {dist.distType === 'fixed' && <div><strong>Value:</strong> {dist.value}</div>}
+      {(dist.distType === 'normal' || dist.distType === 'GBM') && (
+        <>
+          <div><strong>Mean:</strong> {dist.mean}</div>
+          <div><strong>Sigma:</strong> {dist.sigma}</div>
+        </>
+      )}
+      {dist.distType === 'uniform' && (
+        <>
+          <div><strong>Lower:</strong> {dist.lower}</div>
+          <div><strong>Upper:</strong> {dist.upper}</div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const ScenarioDetailPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const scenarioId = searchParams.get('id');
+
+  const [scenario, setScenario] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isInvestmentWizardOpen, setInvestmentWizardOpen] = useState(false);
+
+  // Always fetch the full scenario data from the backend.
+  useEffect(() => {
+    axios
+      .get(`${BACKEND_URL}/api/scenario/?id=${scenarioId}`, { withCredentials: true })
+      .then((response) => {
+        if (response.data.scenario) {
+          setScenario(response.data.scenario);
+        } else {
+          throw new Error('No scenario found.');
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [scenarioId]);
+
+  // Update the scenario using the POST save endpoint.
+  const updateScenario = async (updatedScenario) => {
+    try {
+      // Build a complete payload by merging the scenario ID with the updated full scenario.
+      const payload = {
+        scenarioId: scenario._id,
+        ...updatedScenario
+      };
+      const response = await axios.post(
+        `${BACKEND_URL}/api/scenario/save/`,
+        payload,
+        { withCredentials: true }
+      );
+      if (response.data.success) {
+        if (response.data.scenario) {
+          setScenario(response.data.scenario);
+          return response.data.scenario;
+        } else {
+          setScenario({ ...scenario, ...updatedScenario });
+          return { ...scenario, ...updatedScenario };
+        }
+      }
+    } catch (err) {
+      console.error("Update failed:", err);
+    }
+  };
+
+  // Handler for new investment submission from the InvestmentWizard.
+  const handleInvestmentSubmit = async (newInvestment) => {
+    console.log("Adding investment:", newInvestment);
+    const updatedInvestments = scenario.investments
+        ? [...scenario.investments, newInvestment]
+        : [newInvestment];
+
+    const updatedScenario = { ...scenario, investments: updatedInvestments };
+    
+    // 1) Save to the DB
+    const saved = await updateScenario(updatedScenario);
+
+    if (saved) {
+        // 2) Now close the wizard
+        setInvestmentWizardOpen(false);
+    } else {
+        // optionally show an error toast here
+        console.error("Failed to save new investment");
+    }
+  };
+
+  if (loading) return <div>Loading scenario...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!scenario) return <div>No scenario data available</div>;
+
+  // Determine if the scenario is for a married person.
+  const isMarried = scenario.maritalStatus;
+  const yourBirthYear = scenario.birthYears ? scenario.birthYears[0] : 'N/A';
+  const spouseBirthYear = isMarried && scenario.birthYears && scenario.birthYears[1] ? scenario.birthYears[1] : 'N/A';
+
+  // Define a common button style
+  const buttonStyle = {
+    backgroundColor: 'rgb(175, 244, 198)',
+    padding: '8px 16px',
+    fontSize: '1rem',
+    border: 'none',
+    cursor: 'pointer',
+    marginBottom: '20px'
+  };
+
+  return (
+    <div className="scenario-detail-page" style={{ padding: '20px' }}>
+      <h1>Scenario Detail</h1>
+
+      {/* Button to open the edit modal */}
+      <button 
+        onClick={() => setIsEditModalOpen(true)}
+        style={buttonStyle}
+      >
+        Edit Scenario
+      </button>
+
+      {/* General Information */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>General Information</h2>
+        <div><strong>Name:</strong> {scenario.name}</div>
+        <div><strong>Marital Status:</strong> {isMarried ? 'Married' : 'Single'}</div>
+        <div><strong>Your Birth Year:</strong> {yourBirthYear}</div>
+        {isMarried && <div><strong>Spouse Birth Year:</strong> {spouseBirthYear}</div>}
+      </section>
+
+      {/* Life Expectancy */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Life Expectancy</h2>
+        {isMarried ? (
+          <>
+            <div style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <h3>Your Life Expectancy</h3>
+              {scenario.lifeExpectancy && scenario.lifeExpectancy[0]
+                ? renderValueDistribution(scenario.lifeExpectancy[0])
+                : 'N/A'}
+            </div>
+            <div style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <h3>Spouse Life Expectancy</h3>
+              {scenario.lifeExpectancy && scenario.lifeExpectancy[1]
+                ? renderValueDistribution(scenario.lifeExpectancy[1])
+                : 'N/A'}
+            </div>
+          </>
+        ) : (
+          <div style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+            {scenario.lifeExpectancy && scenario.lifeExpectancy[0]
+              ? renderValueDistribution(scenario.lifeExpectancy[0])
+              : 'N/A'}
+          </div>
+        )}
+      </section>
+
+      {/* Investments */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Investments</h2>
+        {Array.isArray(scenario.investments) && scenario.investments.length > 0 ? (
+          scenario.investments.map((inv, index) => (
+            <div key={index} style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <div>
+                <strong>Investment:</strong> {inv.investmentType?.name || inv.name} ({inv.taxStatus})
+              </div>
+              <div>
+                <strong>Description:</strong> {inv.investmentType ? inv.investmentType.description : inv.description}
+              </div>
+              <div><strong>Value:</strong> {inv.value}</div>
+              <div><strong>Expense Ratio:</strong> {inv.investmentType?.expenseRatio}</div>
+              <div>
+                <strong>Return Distribution:</strong>{' '}
+                {inv.investmentType?.returnDistribution && renderValueDistribution(inv.investmentType.returnDistribution)}
+              </div>
+              <div>
+                <strong>Income Distribution:</strong>{' '}
+                {inv.investmentType?.incomeDistribution && renderValueDistribution(inv.investmentType.incomeDistribution)}
+              </div>
+            </div>
+          ))
+        ) : (
+          <div>N/A</div>
+        )}
+        {/* Button to open the Investment Wizard */}
+        <button 
+          onClick={() => setInvestmentWizardOpen(true)}
+          style={{ ...buttonStyle, marginTop: '10px', marginBottom: '10px' }}
+        >
+          Add Investment
+        </button>
+      </section>
+
+      {/* Add Events Button */}
+      <button 
+        onClick={() => navigate(`/scenario/edit?id=${scenarioId}`)}
+        style={buttonStyle}
+      >
+         Add Events
+      </button>
+
+      {/* Income Events */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Income Events</h2>
+        {Array.isArray(scenario.incomeEvents) && scenario.incomeEvents.length > 0 ? (
+          scenario.incomeEvents.map((income, index) => (
+            <div key={index} style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <div><strong>Name:</strong> {income.name}</div>
+              <div><strong>Description:</strong> {income.description}</div>
+              <div>
+                <strong>Start:</strong>{' '}
+                {income.start?.startDistribution ? renderValueDistribution(income.start.startDistribution) : 'N/A'}
+              </div>
+              <div>
+                <strong>Duration:</strong>{' '}
+                {income.duration ? renderValueDistribution(income.duration) : 'N/A'}
+              </div>
+              <div><strong>Initial Amount:</strong> {income.initialAmount}</div>
+              <div><strong>Change (Amt or %):</strong> {income.changeAmtOrPct}</div>
+              <div>
+                <strong>Change Distribution:</strong>{' '}
+                {income.changeDistribution ? renderValueDistribution(income.changeDistribution) : 'N/A'}
+              </div>
+              <div><strong>Inflation Adjusted:</strong> {income.inflationAdjusted ? 'Yes' : 'No'}</div>
+              <div><strong>User Fraction:</strong> {income.userFraction}</div>
+              <div><strong>Social Security:</strong> {income.socialSecurity ? 'Yes' : 'No'}</div>
+            </div>
+          ))
+        ) : (
+          <div>N/A</div>
+        )}
+      </section>
+
+      {/* Expense Events */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Expense Events</h2>
+        {Array.isArray(scenario.expenseEvents) && scenario.expenseEvents.length > 0 ? (
+          scenario.expenseEvents.map((expense, index) => (
+            <div key={index} style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <div><strong>Name:</strong> {expense.name}</div>
+              <div><strong>Description:</strong> {expense.description}</div>
+              <div>
+                <strong>Start:</strong>{' '}
+                {expense.start?.startDistribution ? renderValueDistribution(expense.start.startDistribution) : 'N/A'}
+              </div>
+              <div>
+                <strong>Duration:</strong>{' '}
+                {expense.duration ? renderValueDistribution(expense.duration) : 'N/A'}
+              </div>
+              <div><strong>Initial Amount:</strong> {expense.initialAmount}</div>
+              <div><strong>Change (Amt or %):</strong> {expense.changeAmtOrPct}</div>
+              <div>
+                <strong>Change Distribution:</strong>{' '}
+                {expense.changeDistribution ? renderValueDistribution(expense.changeDistribution) : 'N/A'}
+              </div>
+              <div><strong>Inflation Adjusted:</strong> {expense.inflationAdjusted ? 'Yes' : 'No'}</div>
+              <div><strong>User Fraction:</strong> {expense.userFraction}</div>
+              <div><strong>Discretionary:</strong> {expense.discretionary ? 'Yes' : 'No'}</div>
+            </div>
+          ))
+        ) : (
+          <div>N/A</div>
+        )}
+      </section>
+
+      {/* Invest Events */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Invest Events</h2>
+        {Array.isArray(scenario.investEvents) && scenario.investEvents.length > 0 ? (
+          scenario.investEvents.map((invest, index) => (
+            <div key={index} style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <div><strong>Name:</strong> {invest.name}</div>
+              <div><strong>Description:</strong> {invest.description}</div>
+              <div>
+                <strong>Start:</strong>{' '}
+                {invest.start?.startDistribution ? renderValueDistribution(invest.start.startDistribution) : 'N/A'}
+              </div>
+              <div>
+                <strong>Duration:</strong>{' '}
+                {invest.duration ? renderValueDistribution(invest.duration) : 'N/A'}
+              </div>
+              <div>
+                <strong>Asset Allocation:</strong>
+                {invest.assetAllocation ? (
+                  Array.from(invest.assetAllocation.entries()).map(([key, value]) => (
+                    <div key={key} style={{ marginLeft: '1rem' }}>
+                      {key}: {value}
+                    </div>
+                  ))
+                ) : (
+                  'N/A'
+                )}
+              </div>
+              <div><strong>Glide Path:</strong> {invest.glidePath ? 'Yes' : 'No'}</div>
+              {invest.assetAllocation2 && (
+                <div>
+                  <strong>Asset Allocation 2:</strong>
+                  {Array.from(invest.assetAllocation2.entries()).map(([key, value]) => (
+                    <div key={key} style={{ marginLeft: '1rem' }}>
+                      {key}: {value}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))
+        ) : (
+          <div>N/A</div>
+        )}
+      </section>
+
+      {/* Rebalance Events */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Rebalance Events</h2>
+        {Array.isArray(scenario.rebalanceEvents) && scenario.rebalanceEvents.length > 0 ? (
+          scenario.rebalanceEvents.map((rebalance, index) => (
+            <div key={index} style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+              <div><strong>Name:</strong> {rebalance.name}</div>
+              <div><strong>Description:</strong> {rebalance.description}</div>
+              <div>
+                <strong>Start:</strong>{' '}
+                {rebalance.start?.startDistribution ? renderValueDistribution(rebalance.start.startDistribution) : 'N/A'}
+              </div>
+              <div>
+                <strong>Duration:</strong>{' '}
+                {rebalance.duration ? renderValueDistribution(rebalance.duration) : 'N/A'}
+              </div>
+              <div>
+                <strong>Asset Allocation:</strong>
+                {rebalance.assetAllocation ? (
+                  Array.from(rebalance.assetAllocation.entries()).map(([key, value]) => (
+                    <div key={key} style={{ marginLeft: '1rem' }}>
+                      {key}: {value}
+                    </div>
+                  ))
+                ) : (
+                  'N/A'
+                )}
+              </div>
+            </div>
+          ))
+        ) : (
+          <div>N/A</div>
+        )}
+      </section>
+
+      {/* Other Settings */}
+      <section style={{ marginBottom: '20px' }}>
+        <h2>Other Settings</h2>
+        <div>
+          <strong>Inflation Assumption:</strong>{' '}
+          {scenario.inflationAssumption ? renderValueDistribution(scenario.inflationAssumption) : 'N/A'}
+        </div>
+        <div>
+          <strong>After-Tax Contribution Limit:</strong> {scenario.afterTaxContributionLimit}
+        </div>
+        <div>
+          <strong>Spending Strategy:</strong>{' '}
+          {Array.isArray(scenario.spendingStrategy) ? scenario.spendingStrategy.join(', ') : 'N/A'}
+        </div>
+        <div>
+          <strong>Expense Withdrawal Strategy:</strong>{' '}
+          {Array.isArray(scenario.expenseWithdrawalStrategy)
+            ? scenario.expenseWithdrawalStrategy.join(', ')
+            : 'N/A'}
+        </div>
+        <div>
+          <strong>Financial Goal:</strong> {scenario.financialGoal}
+        </div>
+        <div>
+          <strong>Residence State:</strong> {scenario.residenceState}
+        </div>
+      </section>
+
+      <button
+        style={buttonStyle}
+        onClick={() => navigate('/scenario')}
+      >
+        Back to Scenarios
+      </button>
+
+      {/* Edit Modal */}
+      <ScenarioEditModal 
+         open={isEditModalOpen} 
+         onClose={() => setIsEditModalOpen(false)} 
+         scenario={scenario} 
+         updateScenario={updateScenario}
+      />
+    
+      {/* Investment Wizard Modal */}
+      {isInvestmentWizardOpen && (
+        <InvestmentWizard 
+          open={isInvestmentWizardOpen} 
+          onClose={() => setInvestmentWizardOpen(false)} 
+          onSubmit={handleInvestmentSubmit}
+        />
+      )}
+    </div>
+  );
+}
+
+export default ScenarioDetailPage;

--- a/client/src/pages/Scenarios/components/ScenarioListItem.jsx
+++ b/client/src/pages/Scenarios/components/ScenarioListItem.jsx
@@ -1,31 +1,45 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import dropdownLogo from '/src/assets/icons/chevron_down.svg'
 import DropdownMenu from './DropdownMenu'
 
-const BACKEND_URL = import.meta.env.VITE_BACKEND_URL
+const ScenarioListItem = ({ name, scenarioId, editScenario, deleteScenario, exportScenario }) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const navigate = useNavigate()
 
+  // Updated: Navigate to the detail route using a query string.
+  const handleViewScenario = () => {
+    navigate(`/scenario/detail?id=${scenarioId}`, { state: { scenario: { name, scenarioId } } })
+  }
 
-const ScenarioListItem = ({name, scenarioId, editScenario, deleteScenario, exportScenario}) => {
+  return (
+    <div className="scenario-list-item">
+      <h4 className="scenario-title">{name}</h4>
+      
+      {/* View Button: now goes to "/scenario/detail?id=..." */}
+      <button className="scenario-list-view-button" onClick={handleViewScenario}>
+        View
+      </button>
 
-    const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+      {/* Dropdown menu toggle button */}
+      <button
+        className="scenario-list-show-dropdown-button"
+        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        disabled={isDropdownOpen}
+      >
+        <img src={dropdownLogo} alt="Toggle Dropdown" />
+      </button>
 
-
-    return (
-        <div className="scenario-list-item">
-            <h4 className="scenario-title">{name}</h4>
-            <button className="scenario-list-show-dropdown-button" onClick={() => setIsDropdownOpen(!isDropdownOpen)} disabled={isDropdownOpen}>
-                <img src={dropdownLogo}/>
-            </button>
-            <DropdownMenu 
-                open={isDropdownOpen} 
-                setOpen={setIsDropdownOpen} 
-                scenarioId={scenarioId}
-                editScenario={editScenario}
-                deleteScenario={deleteScenario}
-                exportScenario={exportScenario}
-            />
-        </div>
-    )
+      <DropdownMenu
+        open={isDropdownOpen}
+        setOpen={setIsDropdownOpen}
+        scenarioId={scenarioId}
+        editScenario={editScenario}
+        deleteScenario={deleteScenario}
+        exportScenario={exportScenario}
+      />
+    </div>
+  )
 }
 
 export default ScenarioListItem

--- a/server/models/ScenarioModel.js
+++ b/server/models/ScenarioModel.js
@@ -215,9 +215,9 @@ const ScenarioSchema = new Schema({
     birthYears: {
         type: [Number],
     },
-    lifeExpectancy: {
-        type: valueDistributionSchema,
-    },
+    lifeExpectancy: [{
+  type: valueDistributionSchema,
+}],
     investments: [investmentSchema],
     incomeEvents: [incomeEventSchema],
     expenseEvents: [expenseEventSchema],

--- a/server/routes/scenarioRoutes.js
+++ b/server/routes/scenarioRoutes.js
@@ -115,32 +115,31 @@ router.get('/api/scenario/', getUserAuth, async (req, res) => {
 
 })
 
-//Save an existing scenario
 router.post('/api/scenario/save/', getUserAuth, async (req, res) => {
-    
-    const scenarioId = req.body.scenarioId
-    const userId = req.user._id
-
-    const scenario = await ScenarioModel.findOne({_id: scenarioId})
-    if (!scenario) {
-        return res.status(404).json({error: 'Scenario not found!'})
-    }
-
+    const { scenarioId, ...updates } = req.body;
+    const userId = req.user._id;
+  
+    const scenario = await ScenarioModel.findById(scenarioId);
+    if (!scenario) return res.status(404).json({ error: 'Scenario not found!' });
+  
     if (scenario.owner !== userId && !scenario.editors.includes(userId)) {
-        return res.status(403).json({error: 'You do not have permission to save this scenario!'})
+      return res.status(403).json({ error: 'No permission to save this scenario!' });
     }
-
-    scenario.name = req.body.name
-
+  
+    // Assign all incoming fields onto the mongoose document
+    Object.entries(updates).forEach(([key, val]) => {
+      scenario[key] = val;
+    });
+  
     try {
-        await scenario.save()
-        return res.status(200).json({success: true})
+      await scenario.save();
+      return res.status(200).json({ success: true, scenario });
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: error.message });
     }
-    catch(error) {
-        console.log(error)
-        return res.status(500).json({error: error})
-    }
-})
+  });
+  
 
 ///Delete a scenario
 router.post('/api/scenario/delete/', getUserAuth, async (req, res) => {


### PR DESCRIPTION
Add a new ScenarioDetailPage and InvestmentWizard so you can add investments in a multi-step modal, view them on the detail page, and save everything back to /api/scenario/save/. I also tweaked the ScenarioCreateNameModal for keyboard shortcuts and reset behavior, cleaned up the save endpoint to merge updates and return the latest scenario, and configured the routing so that view and add investments and edit buttons function.